### PR TITLE
Implement single-shot semantics

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -560,7 +560,7 @@ let rec instr s =
     let bt = block_type s in
     let es' = instr_block s in
     end_ s;
-    guard bt es'
+    barrier bt es'
 
   | 0xfc as b ->
     (match vu32 s with

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -218,7 +218,7 @@ let encode m =
       | Suspend x -> op 0xe1; var x
       | Resume xls -> op 0xe2; vec var_pair xls
       | ResumeThrow x -> op 0xe3; var x
-      | Guard (bt, es) -> op 0xe4; block_type bt; list instr es; end_ ()
+      | Barrier (bt, es) -> op 0xe4; block_type bt; list instr es; end_ ()
 
       | Drop -> op 0x1a
       | Select None -> op 0x1b

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -100,7 +100,7 @@ and instr' =
   | Suspend of idx                    (* suspend continuation *)
   | Resume of (idx * idx) list        (* resume continuation *)
   | ResumeThrow of idx                (* abort continuation *)
-  | Guard of block_type * instr list  (* guard against suspension *)
+  | Barrier of block_type * instr list  (* guard against suspension *)
   | LocalGet of idx                   (* read local idxiable *)
   | LocalSet of idx                   (* write local idxiable *)
   | LocalTee of idx                   (* write local idxiable and keep value *)

--- a/interpreter/syntax/free.ml
+++ b/interpreter/syntax/free.ml
@@ -109,7 +109,7 @@ let rec instr (e : instr) =
   | RefNull t -> heap_type t
   | RefFunc x -> funcs (idx x)
   | Const _ | Test _ | Compare _ | Unary _ | Binary _ | Convert _ -> empty
-  | Block (bt, es) | Loop (bt, es) | Guard (bt, es) -> block_type bt ++ block es
+  | Block (bt, es) | Loop (bt, es) | Barrier (bt, es) -> block_type bt ++ block es
   | If (bt, es1, es2) -> block_type bt ++ block es1 ++ block es2
   | Let (bt, ts, es) ->
     let free = block_type bt ++ block es in

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -42,7 +42,7 @@ let cont_new x = ContNew x
 let suspend x = Suspend x
 let resume xys = Resume xys
 let resume_throw x = ResumeThrow x
-let guard bt es = Guard (bt, es)
+let barrier bt es = Barrier (bt, es)
 
 let local_get x = LocalGet x
 let local_set x = LocalSet x

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -281,7 +281,7 @@ let rec instr e =
       "resume",
       List.map (fun (x, y) -> Node ("event " ^ var x ^ " " ^ var y, [])) xys
     | ResumeThrow x -> "resume_throw " ^ var x, []
-    | Guard (bt, es) -> "guard", block_type bt @ list instr es
+    | Barrier (bt, es) -> "barrier", block_type bt @ list instr es
     | LocalGet x -> "local.get " ^ var x, []
     | LocalSet x -> "local.set " ^ var x, []
     | LocalTee x -> "local.tee " ^ var x, []

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -219,7 +219,7 @@ rule token = parse
   | "suspend" { SUSPEND }
   | "resume" { RESUME }
   | "resume_throw" { RESUME_THROW }
-  | "guard" { GUARD }
+  | "barrier" { BARRIER }
 
   | "local.get" { LOCAL_GET }
   | "local.set" { LOCAL_SET }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -217,7 +217,7 @@ let inline_func_type_explicit (c : context) x ft at =
 %token UNREACHABLE NOP DROP SELECT
 %token BLOCK END IF THEN ELSE LOOP LET
 %token THROW TRY DO CATCH CATCH_ALL
-%token CONT_NEW SUSPEND RESUME RESUME_THROW GUARD
+%token CONT_NEW SUSPEND RESUME RESUME_THROW BARRIER
 %token BR BR_IF BR_TABLE BR_ON_NULL
 %token CALL CALL_REF CALL_INDIRECT RETURN RETURN_CALL_REF FUNC_BIND
 %token LOCAL_GET LOCAL_SET LOCAL_TEE GLOBAL_GET GLOBAL_SET
@@ -626,8 +626,8 @@ block_instr :
   | TRY labeling_opt block CATCH labeling_end_opt LPAR EXCEPTION var RPAR instr_list END labeling_end_opt
     { fun c -> let c' = $2 c ($5 @ $12) in
       let ts, es1 = $3 c' in try_ ts es1 (Some ($8 c' event)) ($10 c') }
-  | GUARD labeling_opt block END labeling_end_opt
-    { fun c -> let c' = $2 c $5 in let bt, es = $3 c' in guard bt es }
+  | BARRIER labeling_opt block END labeling_end_opt
+    { fun c -> let c' = $2 c $5 in let bt, es = $3 c' in barrier bt es }
 
 block :
   | type_use block_param_body
@@ -744,8 +744,8 @@ expr1 :  /* Sugar */
     { fun c ->
       let bt, (es1, xo, es2) = $2 c in
       [], try_ bt es1 xo es2 }
-  | GUARD labeling_opt block
-    { fun c -> let c' = $2 c [] in let bt, es = $3 c' in [], guard bt es }
+  | BARRIER labeling_opt block
+    { fun c -> let c' = $2 c [] in let bt, es = $3 c' in [], barrier bt es }
 
 select_expr_results :
   | LPAR RESULT value_type_list RPAR select_expr_results

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -486,7 +486,7 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
     | _ -> assert false
     )
 
-  | Guard (bt, es) ->
+  | Barrier (bt, es) ->
     let FuncType (ts1, ts2) as ft = check_block_type c bt e.at in
     check_block {c with labels = ts2 :: c.labels} es ft e.at;
     ts1 --> ts2


### PR DESCRIPTION
Also rename `guard` to `barrier`.