### PR TITLE
Variant of the semantics in which cont.bind does not allocate

### DIFF
--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -516,12 +516,12 @@ let rec check_instr (c : context) (e : instr) (s : infer_result_type) : op_type 
         let EventType (FuncType (ts3, ts4), res) = event c x1 in
         require (res = Resumable) x1.at "handling a non-resumable event";
         match Lib.List.last_opt (label c x2) with
-        | Some (RefType (NonNullable, DefHeapType (SynVar y'))) ->
+        | Some (RefType (nul', DefHeapType (SynVar y'))) ->
           let ContType z' = cont_type c (y' @@ x2.at) in
-          let FuncType (ts1', ts2') = func_type c (as_syn_var z' @@ x2.at) in
-          check_stack c ts4 ts1' x2.at;
-          check_stack c ts2 ts2' x2.at;
-          check_stack c (ts3 @ [RefType (NonNullable, DefHeapType (SynVar y'))]) (label c x2) x2.at
+          let ft' = func_type c (as_syn_var z' @@ x2.at) in
+          require (match_func_type c.types [] (FuncType (ts4, ts2)) ft') x2.at
+            "type mismatch in continuation type";
+          check_stack c (ts3 @ [RefType (nul', DefHeapType (SynVar y'))]) (label c x2) x2.at
         | _ ->
          error e.at
            ("type mismatch: instruction requires continuation reference type" ^

--- a/proposals/continuations/Overview.md
+++ b/proposals/continuations/Overview.md
@@ -1,0 +1,157 @@
+# Typed Continuations for WebAssembly
+
+## Language Extensions
+
+Based on [typed reference proposal](https://github.com/WebAssembly/function-references/blob/master/proposals/function-references/Overview.md) and [exception handling proposal](https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md).
+
+
+### Types
+
+#### Defined Types
+
+* `cont <typeidx>` is a new form of defined type
+  - `(cont $ft) ok` iff `$ft ok` and `$ft = [t1*] -> [t2*]`
+
+
+### Instructions
+
+* `cont.new <typeidx>` creates a new continuation
+  - `cont.new $ct : [(ref $ft)] -> [(ref $ct)]`
+    - iff `$ct = cont $ft`
+
+* `cont.bind <typidx>` binds a continuation to (partial) arguments
+  - `cont.bind $ct : [t3* (ref null? $ct')] -> [(ref $ct)]`
+    - iff `$ct = cont $ft`
+    - and `$ft = [t1*] -> [t2*]`
+    - and `$ct' = cont $ft'`
+    - and `$ft' = [t3* t1'*] -> [t2'*]`
+    - and `[t1'*] -> [t2'*] <: [t1*] -> [t2*]`
+
+* `suspend <evtidx>` suspends the current continuation
+  - `suspend $e : [t1*] -> [t2*]`
+    - iff `event $e : [t1*] -> [t2*]`
+
+* `resume (event <evtidx> <labelidx>)*` resumes a continuation
+  - `resume (event $e $l)* : [t1* (ref null? $ct)] -> [t2*]`
+    - iff `$ct = cont $ft`
+    - and `$ft = [t1*] -> [t2*]`
+    - and `(event $e : [te1*] -> [te2*])*`
+    - and `(label $l : [te1'* (ref null? $ct')])*`
+    - and `([te1*] <: [te1'*])*`
+    - and `($ct' = cont $ft')*`
+    - and `([te2*] -> [t2*] <: $ft')*`
+
+* `resume_throw <evtidx>` aborts a continuation
+  - `resume_throw $e : [te* (ref null? $ct)] -> [t2*]`
+    - iff `exception $e : [te*]`
+    - and `$ct = cont $ft`
+    - and `$ft = [t1*] -> [t2*]`
+
+* `barrier <blocktype> <instr>* end` blocks suspension
+  - `barrier $l bt instr* end : [t1*] -> [t2*]`
+    - iff `bt = [t1*] -> [t2*]`
+    - and `instr* : [t1*] -> [t2*]` with labels extended with `[t2*]`
+
+
+## Reduction Semantics
+
+### Store extensions
+
+* New store component `evts` for allocated events
+  - `S ::= {..., evts <evtinst>*}`
+
+* An *event instance* represents an event tag
+  - `evtinst ::= {type <evttype>}`
+
+* New store component `conts` for allocated continuations
+  - `S ::= {..., conts <cont>?*}`
+
+* A continuation is a context annotated with its hole's arity
+  - `cont ::= (E : n)`
+
+
+### Administrative instructions
+
+* `(ref.cont a)` represents a continuation value, where `a` is a *continuation address* indexing into the store's `conts` component
+  - `ref.cont a : [] -> [(ref $ct)]`
+    - iff `S.conts[a] = epsilon \/ S.conts[a] = (E : n)`
+    - and `$ct = cont $ft`
+    - and `$ft = [t1^n] -> [t2*]`
+
+* `(handle{(<evtaddr> <labelidx>)*}? <instr>* end)` represents an active handler (or a barrier when no handler list is present)
+  - `(handle{(a $l)*}? instr* end) : [t1*] -> [t2*]`
+    - iff `instr* : [t1*] -> [t2*]`
+    - and `(S.evts[a].type = [te1*] -> [te2*])*`
+    - and `(label $l : [te1'* (ref null? $ct')])*`
+    - and `([te1*] <: [te1'*])*`
+    - and `($ct' = cont $ft')*`
+    - and `([te2*] -> [t2*] <: $ft')*`
+
+
+### Handler contexts
+
+```
+H^ea ::=
+  _
+  val* H^ea instr*
+  label_n{instr*} H^ea end
+  frame_n{F} H^ea end
+  catch{...} H^ea end
+  handle{(ea' $l)} H^ea end   (iff ea notin e1'*)
+```
+
+
+### Reduction
+
+* `S; F; (ref.null t) (cont.new $ct)  -->  S; F; trap`
+
+* `S; F; (ref.func fa) (cont.new $ct)  -->  S'; F; (ref.cont |S.conts|)`
+  - iff `S' = S with conts += (E : n)`
+  - and `E = _ (invoke fa)`
+  - and `$ct = cont $ft`
+  - and `$ft = [t1^n] -> [t2*]`
+
+* `S; F; (ref.null t) (cont.bind $ct)  -->  S; F; trap`
+
+* `S; F; (ref.cont ca) (cont.bind $ct)  -->  S'; F; trap`
+  - iff `S.conts[ca] = epsilon`
+
+* `S; F; v^n (ref.cont ca) (cont.bind $ct)  -->  S'; F; (ref.const |S.conts|)`
+  - iff `S.conts[ca] = (E' : n')`
+  - and `$ct = cont $ft`
+  - and `$ft = [t1'*] -> [t2'*]`
+  - and `n = n' - |t1'*|`
+  - and `S' = S with conts[ca] = epsilon with conts += (E : n' - n)`
+  - and `E = v^n E'`
+
+* `S; F; (ref.null t) (resume (event $e $l)*)  -->  S; F; trap`
+
+* `S; F; (ref.cont ca) (resume (event $e $l)*)  -->  S; F; trap`
+  - iff `S.conts[ca] = epsilon`
+
+* `S; F; v^n (ref.cont ca) (resume (event $e $l)*)  -->  S'; F; handle{(ea $l)*} E[v^n] end`
+  - iff `S.conts[ca] = (E : n)`
+  - and `(ea = F.evts[$e])*`
+  - and `S' = S with conts[ca] = epsilon`
+
+* `S; F; (ref.null t) (resume_throw $e)  -->  S; F; trap`
+
+* `S; F; (ref.cont ca) (resume_throw $e)  -->  S; F; trap`
+  - iff `S.conts[ca] = epsilon`
+
+* `S; F; v^m (ref.cont ca) (resume_throw $e)  -->  S'; F; E[v^m (throw $e)]`
+  - iff `S.conts[ca] = (E : n)`
+  - and `S.evts[F.evts[$e]].type = [t1^m] -> [t2*]`
+  - and `S' = S with conts[ca] = epsilon`
+
+* `S; F; (barrier bt instr* end)  -->  S; F; handle instr* end`
+
+* `S; F; (handle{(e $l)*}? v* end)  -->  S; F; v*`
+
+* `S; F; (handle H^ea[(suspend $e)] end)  --> S; F; trap`
+  - iff `ea = F.evts[$e]`
+
+* `S; F; (handle{(ea1 $l1)* (ea $l) (ea2 $l2)*} H^ea[v^n (suspend $e)] end)  --> S'; F; (v^n) (ref.cont |S.conts|) (br $l)`
+  - iff `ea = F.evts[$e]`
+  - and `S.evts[ea].type = [t1^n] -> [t2^m]`
+  - and `S' = S with conts += (H^ea : m)`

--- a/proposals/continuations/Overview.md
+++ b/proposals/continuations/Overview.md
@@ -122,7 +122,7 @@ H^ea ::=
   - and `$ft = [t1'*] -> [t2'*]`
   - and `n = n' - |t1'*|`
   - and `S' = S with conts[ca] = epsilon with conts += (E : n' - n)`
-  - and `E = v^n E'`
+  - and `E = E'[v^n _]`
 
 * `S; F; (ref.null t) (resume (event $e $l)*)  -->  S; F; trap`
 

--- a/proposals/continuations/Overview.md
+++ b/proposals/continuations/Overview.md
@@ -69,19 +69,31 @@ Based on [typed reference proposal](https://github.com/WebAssembly/function-refe
 * A continuation is a context annotated with its hole's arity
   - `cont ::= (E : n)`
 
+* New store component `contrefs` for continuation references
+  - `S ::= {..., contrefs <contref>*}`
+
+* A continuation reference is a continuation body address annotated
+  with its expected arity (if the expected arity and actual arity do
+  not match then the continuation is no longer live and any attempt to
+  access it will result in a trap)
+  - `contref ::= (cb : n)`
+
 
 ### Administrative instructions
 
-* `(ref.cont a)` represents a continuation value, where `a` is a *continuation address* indexing into the store's `conts` component
-  - `ref.cont a : [] -> [(ref $ct)]`
-    - iff `S.conts[a] = epsilon \/ S.conts[a] = (E : n)`
+* `(ref.cont ca)` represents a continuation value, where `ca` is a
+  *continuation address* indexing into the store's `contrefs`
+  component, which in turn indexes into the store's `conts` component
+  via a continuation body address
+  - `ref.cont ca : [] -> [(ref $ct)]`
+    - iff `S.contrefs[ca] = (cb : n) /\ (S.const[cb] = epsilon \/ S.conts[cb] = (E : m))`
     - and `$ct = cont $ft`
     - and `$ft = [t1^n] -> [t2*]`
 
 * `(handle{(<evtaddr> <labelidx>)*}? <instr>* end)` represents an active handler (or a barrier when no handler list is present)
-  - `(handle{(a $l)*}? instr* end) : [t1*] -> [t2*]`
+  - `(handle{(ea $l)*}? instr* end) : [t1*] -> [t2*]`
     - iff `instr* : [t1*] -> [t2*]`
-    - and `(S.evts[a].type = [te1*] -> [te2*])*`
+    - and `(S.evts[ea].type = [te1*] -> [te2*])*`
     - and `(label $l : [te1'* (ref null? $ct')])*`
     - and `([te1*] <: [te1'*])*`
     - and `($ct' = cont $ft')*`
@@ -105,24 +117,26 @@ H^ea ::=
 
 * `S; F; (ref.null t) (cont.new $ct)  -->  S; F; trap`
 
-* `S; F; (ref.func fa) (cont.new $ct)  -->  S'; F; (ref.cont |S.conts|)`
-  - iff `S' = S with conts += (E : n)`
+* `S; F; (ref.func fa) (cont.new $ct)  -->  S'; F; (ref.cont |S.contrefs|)`
+  - iff `S' = S with contrefs += (cb : n), ..., (cb : 0) and conts += (E : n)`
   - and `E = _ (invoke fa)`
   - and `$ct = cont $ft`
   - and `$ft = [t1^n] -> [t2*]`
+  - and `cb = |S.conts|`
 
 * `S; F; (ref.null t) (cont.bind $ct)  -->  S; F; trap`
 
 * `S; F; (ref.cont ca) (cont.bind $ct)  -->  S'; F; trap`
-  - iff `S.conts[ca] = epsilon`
+  - iff `S.contrefs[ca] = (cb : n)`
+  - and `S.const[cb] = epsilon \/ (S.conts[cb] = (E : n') /\ n =/= n')`
 
-* `S; F; v^n (ref.cont ca) (cont.bind $ct)  -->  S'; F; (ref.const |S.conts|)`
-  - iff `S.conts[ca] = (E' : n')`
+* `S; F; v^n (ref.cont ca) (cont.bind $ct)  -->  S'; F; (ref.cont (ca + n))`
+  - iff `S.contrefs[ca] = (cb : n')`
+  - and `S.conts[cb] = (E : n')`
   - and `$ct = cont $ft`
   - and `$ft = [t1'*] -> [t2'*]`
   - and `n = n' - |t1'*|`
-  - and `S' = S with conts[ca] = epsilon with conts += (E : |t1'*|)`
-  - and `E = E'[v^n _]`
+  - and `S' = S with conts[cb] = (E[v^n _] : |t1'*|)`
 
 * `S; F; (ref.null t) (resume (event $e $l)*)  -->  S; F; trap`
 
@@ -130,19 +144,22 @@ H^ea ::=
   - iff `S.conts[ca] = epsilon`
 
 * `S; F; v^n (ref.cont ca) (resume (event $e $l)*)  -->  S'; F; handle{(ea $l)*} E[v^n] end`
-  - iff `S.conts[ca] = (E : n)`
+  - iff `S.contrefs[ca] = (cb : n)`
+  - and `S.conts[cb] = (E : n)`
   - and `(ea = F.evts[$e])*`
-  - and `S' = S with conts[ca] = epsilon`
+  - and `S' = S with conts[cb] = epsilon`
 
 * `S; F; (ref.null t) (resume_throw $e)  -->  S; F; trap`
 
 * `S; F; (ref.cont ca) (resume_throw $e)  -->  S; F; trap`
-  - iff `S.conts[ca] = epsilon`
+  - iff `S.contrefs[ca] = (cb : n)`
+  - and `S.const[cb] = epsilon \/ (S.conts[cb] = (E : n') /\ n =/= n')`
 
 * `S; F; v^m (ref.cont ca) (resume_throw $e)  -->  S'; F; E[v^m (throw $e)]`
-  - iff `S.conts[ca] = (E : n)`
+  - iff `S.contrefs[ca] = (cb : n)`
+  - iff `S.conts[cb] = (E : n)`
   - and `S.evts[F.evts[$e]].type = [t1^m] -> [t2*]`
-  - and `S' = S with conts[ca] = epsilon`
+  - and `S' = S with conts[cb] = epsilon`
 
 * `S; F; (barrier bt instr* end)  -->  S; F; handle instr* end`
 
@@ -151,8 +168,9 @@ H^ea ::=
 * `S; F; (handle H^ea[(suspend $e)] end)  --> S; F; trap`
   - iff `ea = F.evts[$e]`
 
-* `S; F; (handle{(ea1 $l1)* (ea $l) (ea2 $l2)*} H^ea[v^n (suspend $e)] end)  --> S'; F; v^n (ref.cont |S.conts|) (br $l)`
+* `S; F; (handle{(ea1 $l1)* (ea $l) (ea2 $l2)*} H^ea[v^n (suspend $e)] end)  --> S'; F; v^n (ref.cont |S.contrefs|) (br $l)`
   - iff `ea notin ea1*`
   - and `ea = F.evts[$e]`
   - and `S.evts[ea].type = [t1^n] -> [t2^m]`
-  - and `S' = S with conts += (H^ea : m)`
+  - and `S' = S with contrefs += (cb : m), ..., (cb : 0) and conts += (H^ea : m)`
+  - and `cb = |S.conts|`

--- a/proposals/continuations/Overview.md
+++ b/proposals/continuations/Overview.md
@@ -151,7 +151,8 @@ H^ea ::=
 * `S; F; (handle H^ea[(suspend $e)] end)  --> S; F; trap`
   - iff `ea = F.evts[$e]`
 
-* `S; F; (handle{(ea1 $l1)* (ea $l) (ea2 $l2)*} H^ea[v^n (suspend $e)] end)  --> S'; F; (v^n) (ref.cont |S.conts|) (br $l)`
-  - iff `ea = F.evts[$e]`
+* `S; F; (handle{(ea1 $l1)* (ea $l) (ea2 $l2)*} H^ea[v^n (suspend $e)] end)  --> S'; F; v^n (ref.cont |S.conts|) (br $l)`
+  - iff `ea notin ea1*`
+  - and `ea = F.evts[$e]`
   - and `S.evts[ea].type = [t1^n] -> [t2^m]`
   - and `S' = S with conts += (H^ea : m)`

--- a/proposals/continuations/Overview.md
+++ b/proposals/continuations/Overview.md
@@ -16,7 +16,7 @@ Based on [typed reference proposal](https://github.com/WebAssembly/function-refe
 ### Instructions
 
 * `cont.new <typeidx>` creates a new continuation
-  - `cont.new $ct : [(ref $ft)] -> [(ref $ct)]`
+  - `cont.new $ct : [(ref null? $ft)] -> [(ref $ct)]`
     - iff `$ct = cont $ft`
 
 * `cont.bind <typidx>` binds a continuation to (partial) arguments

--- a/proposals/continuations/Overview.md
+++ b/proposals/continuations/Overview.md
@@ -121,7 +121,7 @@ H^ea ::=
   - and `$ct = cont $ft`
   - and `$ft = [t1'*] -> [t2'*]`
   - and `n = n' - |t1'*|`
-  - and `S' = S with conts[ca] = epsilon with conts += (E : n' - n)`
+  - and `S' = S with conts[ca] = epsilon with conts += (E : |t1'*|)`
   - and `E = E'[v^n _]`
 
 * `S; F; (ref.null t) (resume (event $e $l)*)  -->  S; F; trap`

--- a/proposals/continuations/Overview.md
+++ b/proposals/continuations/Overview.md
@@ -97,7 +97,7 @@ H^ea ::=
   label_n{instr*} H^ea end
   frame_n{F} H^ea end
   catch{...} H^ea end
-  handle{(ea' $l)} H^ea end   (iff ea notin e1'*)
+  handle{(ea' $l)*} H^ea end   (iff ea notin ea'*)
 ```
 
 


### PR DESCRIPTION
The idea is to introduce a layer of indirection in order to allow the continuation itself to be mutated. A continuation reference is a pair `(cb : n)` of an address `cb` into the collection of continuation bodies in the store and the continuation's expected arity `n`. If the expected arity and the actual arity don't match up then attempts to do anything with the continuation will result in a trap. On creation of a continuation we preallocate a continuation reference for each of the continuation's `n+1` possible partial applications.